### PR TITLE
Cached injector for common modules

### DIFF
--- a/guice-extension/src/main/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtension.java
+++ b/guice-extension/src/main/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtension.java
@@ -2,7 +2,7 @@ package name.falgout.jeffrey.testing.junit.guice;
 
 import static java.util.stream.Collectors.toSet;
 import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
 
 import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
@@ -84,8 +84,9 @@ public final class GuiceExtension implements TestInstancePostProcessor, Paramete
       InvocationTargetException {
     Optional<Injector> parentInjector = getParentInjector(context);
     List<? extends Module> modules = getNewModules(context);
+    Set<Class<? extends Module>> moduleClasses = getContextModuleTypes(context);
     if (isSharedInjector(context)) {
-      return createCachedInjector(modules, parentInjector);
+      return createCachedInjector(modules, parentInjector, moduleClasses);
     }
     return parentInjector
             .map(injector -> injector.createChildInjector(modules))
@@ -93,20 +94,17 @@ public final class GuiceExtension implements TestInstancePostProcessor, Paramete
   }
 
   private static Injector createCachedInjector(List<? extends Module> modules,
-      Optional<Injector> parentInjector) {
-    Set<? extends Class<?>> modulClass = modules.stream().map(Object::getClass).collect(toSet());
-    Optional<Injector> cachedInjector = getCachedInjector(modulClass);
-    if (cachedInjector.isPresent()) {
-      return cachedInjector.get();
-    } else {
-      Injector createdInjector = parentInjector
+      Optional<Injector> parentInjector, Set<? extends Class<?>> moduleClasses) {
+    return INJECTOR_CACHE.computeIfAbsent(moduleClasses, classes -> {
+          if (classes.isEmpty()) {
+            //no value for empty moduleClasses
+            return null;
+          }
+          return parentInjector
           .map(injector -> injector.createChildInjector(modules))
           .orElseGet(() -> Guice.createInjector(modules));
-      if (!modulClass.isEmpty()) {
-        INJECTOR_CACHE.put(modulClass, createdInjector);
-      }
-      return createdInjector;
-    }
+        }
+    );
   }
 
   private static boolean isSharedInjector(ExtensionContext context) {
@@ -114,14 +112,7 @@ public final class GuiceExtension implements TestInstancePostProcessor, Paramete
       return false;
     }
     AnnotatedElement element = context.getElement().get();
-    return findAnnotation(element, SharedInjectors.class).isPresent();
-  }
-
-  private static Optional<Injector> getCachedInjector(Set<? extends Class<?>> modulClasses) {
-    if (!modulClasses.isEmpty() && INJECTOR_CACHE.containsKey(modulClasses)) {
-      return Optional.of(INJECTOR_CACHE.get(modulClasses));
-    }
-    return Optional.empty();
+    return isAnnotated(element, SharedInjectors.class);
   }
 
   private static Optional<Injector> getParentInjector(ExtensionContext context)

--- a/guice-extension/src/main/java/name/falgout/jeffrey/testing/junit/guice/SharedInjectors.java
+++ b/guice-extension/src/main/java/name/falgout/jeffrey/testing/junit/guice/SharedInjectors.java
@@ -1,0 +1,20 @@
+package name.falgout.jeffrey.testing.junit.guice;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+@Inherited
+@ExtendWith(GuiceExtension.class)
+public @interface SharedInjectors {
+}

--- a/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtensionTest.java
+++ b/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtensionTest.java
@@ -2,15 +2,12 @@ package name.falgout.jeffrey.testing.junit.guice;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import java.lang.reflect.InvocationTargetException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 import name.falgout.jeffrey.testing.junit.guice.GuiceExtensionTest.TestModule;
 import name.falgout.jeffrey.testing.junit.testing.ExpectFailure;
@@ -171,58 +168,6 @@ class GuiceExtensionTest {
     void cannotBeInjected(NotInjectable notInjectable) {}
   }
 
-    @Nested
-    @IncludeModule(CachedModule.class)
-    @SharedInjectors
-    class FirstCachedInjectorTest {
-
-        @Test
-        void firstTest(long i) {
-            assertEquals(1, i);
-        }
-        @Test
-        void secondTest(long i) {
-            assertEquals(1, i);
-        }
-    }
-
-    @Nested
-    @IncludeModule(CachedModule.class)
-    @SharedInjectors
-    class SecondCachedInjectorTest {
-
-        @Test
-        void firstTest(long i) {
-            assertEquals(1, i);
-        }
-        @Test
-        void secondTest(long i) {
-            assertEquals(1, i);
-        }
-    }
-
-  @Nested
-  @IncludeModule(NonCachedModule.class)
-   class FirstNonCachedInjectorTest {
-    @Test
-    void test(long i) {
-      long expectedValue = NonCachedModule.SECOND_EXECUTED.get() ? 2 : 1;
-      assertEquals(expectedValue, i);
-      NonCachedModule.FIRST_EXECUTED.set(true);
-    }
-  }
-
-  @Nested
-  @IncludeModule(NonCachedModule.class)
-   class SecondNonCachedInjectorTest {
-    @Test
-    void test(long i) {
-      long expectedValue = NonCachedModule.FIRST_EXECUTED.get() ? 2 : 1;
-      assertEquals(expectedValue, i);
-      NonCachedModule.SECOND_EXECUTED.set(true);
-    }
-  }
-
   static final class FooBarExtension implements ParameterResolver {
     @Override
     public boolean supportsParameter(ParameterContext parameterContext,
@@ -303,26 +248,6 @@ class GuiceExtensionTest {
 
     private static class Arg {
       private Arg(String s) {}
-    }
-  }
-
-  static final class CachedModule extends AbstractModule {
-    static final AtomicLong ATOMIC_LONG = new AtomicLong(0);
-    @Override
-    protected void configure() {
-      bind(long.class).toInstance(ATOMIC_LONG.incrementAndGet());
-    }
-  }
-
-  static final class NonCachedModule extends AbstractModule {
-    static final AtomicLong ATOMIC_LONG = new AtomicLong(0);
-    //depend on which test executed first
-    static final AtomicBoolean FIRST_EXECUTED = new AtomicBoolean(false);
-    static final AtomicBoolean SECOND_EXECUTED = new AtomicBoolean(false);
-
-    @Override
-    protected void configure() {
-      bind(long.class).toInstance(ATOMIC_LONG.incrementAndGet());
     }
   }
 }

--- a/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtensionTest.java
+++ b/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtensionTest.java
@@ -170,19 +170,33 @@ class GuiceExtensionTest {
     void cannotBeInjected(NotInjectable notInjectable) {}
   }
 
-  @Nested
-  @IncludeModule(CachedModule.class)
-  class CachedInjector {
+    @Nested
+    @IncludeModule(CachedModule.class)
+    class FirstCachedInjectorTest {
 
-    @Test
-    void firstTest(long i) {
-      assertEquals(CachedModule.ATOMIC_LONG.get(), i);
+        @Test
+        void firstTest(long i) {
+            assertEquals(1, i);
+        }
+        @Test
+        void secondTest(long i) {
+            assertEquals(1, i);
+        }
     }
-    @Test
-    void secondTest(long i) {
-      assertEquals(CachedModule.ATOMIC_LONG.get(), i);
+
+    @Nested
+    @IncludeModule(CachedModule.class)
+    class SecondCachedInjectorTest {
+
+        @Test
+        void firstTest(long i) {
+            assertEquals(1, i);
+        }
+        @Test
+        void secondTest(long i) {
+            assertEquals(1, i);
+        }
     }
-  }
 
   static final class FooBarExtension implements ParameterResolver {
     @Override

--- a/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtensionTest.java
+++ b/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtensionTest.java
@@ -2,12 +2,14 @@ package name.falgout.jeffrey.testing.junit.guice;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 import name.falgout.jeffrey.testing.junit.guice.GuiceExtensionTest.TestModule;
 import name.falgout.jeffrey.testing.junit.testing.ExpectFailure;
@@ -168,6 +170,20 @@ class GuiceExtensionTest {
     void cannotBeInjected(NotInjectable notInjectable) {}
   }
 
+  @Nested
+  @IncludeModule(CachedModule.class)
+  class CachedInjector {
+
+    @Test
+    void firstTest(long i) {
+      assertEquals(CachedModule.ATOMIC_LONG.get(), i);
+    }
+    @Test
+    void secondTest(long i) {
+      assertEquals(CachedModule.ATOMIC_LONG.get(), i);
+    }
+  }
+
   static final class FooBarExtension implements ParameterResolver {
     @Override
     public boolean supportsParameter(ParameterContext parameterContext,
@@ -248,6 +264,14 @@ class GuiceExtensionTest {
 
     private static class Arg {
       private Arg(String s) {}
+    }
+  }
+
+  static final class CachedModule extends AbstractModule {
+    static final AtomicLong ATOMIC_LONG = new AtomicLong(0);
+    @Override
+    protected void configure() {
+      bind(long.class).toInstance(ATOMIC_LONG.incrementAndGet());
     }
   }
 }

--- a/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/SharedInjectorsTest.java
+++ b/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/SharedInjectorsTest.java
@@ -1,0 +1,209 @@
+package name.falgout.jeffrey.testing.junit.guice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.inject.Named;
+import name.falgout.jeffrey.testing.junit.guice.SharedInjectorsTest.OuterClassModule;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(GuiceExtension.class)
+@IncludeModule(OuterClassModule.class)
+@SharedInjectors
+class SharedInjectorsTest {
+
+  private static final Random RANDOM = new Random();
+
+  private static String getRandomString() {
+    return String.valueOf(RANDOM.nextInt(Integer.MAX_VALUE));
+  }
+
+  @Test
+  @IncludeModule(TestCaseModule.class)
+  @SharedInjectors
+  void test1(@Named("base") String base, @Named("test") String test) {
+    assertNotNull(base);
+    assertNotNull(test);
+  }
+
+  @Test
+  @SharedInjectors
+  @IncludeModule(OuterSharedClassModule.class)
+  void testCase2(int value) {
+    assertEquals(1, value);
+  }
+
+
+  @IncludeModule(InnerClassModule.class)
+  @Nested
+  class InnerClass {
+
+    @SharedInjectors
+    @IncludeModule(TestCaseModule.class)
+    @Test
+    void test1(@Named("base") String base,
+        @Named("inner") String inner,
+        @Named("test") String test) {
+      assertNotNull(base);
+      assertNotNull(test);
+      assertNotNull(inner);
+    }
+  }
+
+  @Nested
+  @IncludeModule(CachedModule.class)
+  @SharedInjectors
+  class FirstCachedInjectorTest {
+
+    @Test
+    void firstTest(long i) {
+      assertEquals(1, i);
+    }
+
+    @Test
+    void secondTest(long i) {
+      assertEquals(1, i);
+    }
+  }
+
+  @Nested
+  @IncludeModule(CachedModule.class)
+  @SharedInjectors
+  class SecondCachedInjectorTest {
+
+    @Test
+    void firstTest(long i) {
+      assertEquals(1, i);
+    }
+
+    @Test
+    void secondTest(long i) {
+      assertEquals(1, i);
+    }
+  }
+
+  @Nested
+  @IncludeModule(NonCachedModule.class)
+  class FirstNonCachedInjectorTest {
+
+    @Test
+    void test(long i) {
+      long expectedValue = NonCachedModule.SECOND_EXECUTED.get() ? 2 : 1;
+      assertEquals(expectedValue, i);
+      NonCachedModule.FIRST_EXECUTED.set(true);
+    }
+  }
+
+  @Nested
+  @IncludeModule(NonCachedModule.class)
+  class SecondNonCachedInjectorTest {
+
+    @Test
+    void test(long i) {
+      long expectedValue = NonCachedModule.FIRST_EXECUTED.get() ? 2 : 1;
+      assertEquals(expectedValue, i);
+      NonCachedModule.SECOND_EXECUTED.set(true);
+    }
+  }
+
+  @IncludeModule(OuterSharedClassModule.class)
+  @SharedInjectors
+  @Nested
+  class OuterSharedClass {
+
+    @IncludeModule(ExtraModule.class)
+    @Test
+    void testCase1(int value, @Named("extra") int extra) {
+      assertEquals(1, value);
+      assertEquals(ExtraModule.EXTRA2_EXECUTED.get() ? 2 : 1, extra);
+      ExtraModule.EXTRA1_EXECUTED.set(true);
+    }
+
+    @Test
+    @IncludeModule(ExtraModule.class)
+    void testCase2(int value, @Named("extra") int extra) {
+      assertEquals(1, value);
+      assertEquals(ExtraModule.EXTRA1_EXECUTED.get() ? 2 : 1, extra);
+      ExtraModule.EXTRA2_EXECUTED.set(true);
+    }
+  }
+
+  static class OuterSharedClassModule extends AbstractModule {
+
+    private final static AtomicInteger ATOMIC_INTEGER = new AtomicInteger(0);
+
+    @Override
+    protected void configure() {
+      int value = ATOMIC_INTEGER.incrementAndGet();
+      bind(int.class).toInstance(value);
+      assertEquals(1, value);
+    }
+  }
+
+  static class ExtraModule extends AbstractModule {
+
+    static final AtomicBoolean EXTRA1_EXECUTED = new AtomicBoolean(false);
+    static final AtomicBoolean EXTRA2_EXECUTED = new AtomicBoolean(false);
+    static final AtomicInteger INTEGER = new AtomicInteger(0);
+
+    @Override
+    protected void configure() {
+      bind(int.class).annotatedWith(Names.named("extra")).toInstance(INTEGER.incrementAndGet());
+    }
+  }
+
+  static class OuterClassModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+      bind(String.class).annotatedWith(Names.named("base")).toInstance(getRandomString());
+    }
+  }
+
+  static class InnerClassModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+      bind(String.class).annotatedWith(Names.named("inner")).toInstance(getRandomString());
+    }
+  }
+
+  static class TestCaseModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+      bind(String.class).annotatedWith(Names.named("test")).toInstance(getRandomString());
+    }
+  }
+
+  static final class CachedModule extends AbstractModule {
+
+    static final AtomicLong ATOMIC_LONG = new AtomicLong(0);
+
+    @Override
+    protected void configure() {
+      bind(long.class).toInstance(ATOMIC_LONG.incrementAndGet());
+    }
+  }
+
+  static final class NonCachedModule extends AbstractModule {
+
+    static final AtomicLong ATOMIC_LONG = new AtomicLong(0);
+    //depend on which test executed first
+    static final AtomicBoolean FIRST_EXECUTED = new AtomicBoolean(false);
+    static final AtomicBoolean SECOND_EXECUTED = new AtomicBoolean(false);
+
+    @Override
+    protected void configure() {
+      bind(long.class).toInstance(ATOMIC_LONG.incrementAndGet());
+    }
+  }
+}

--- a/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/SharedInjectorsTest.java
+++ b/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/SharedInjectorsTest.java
@@ -1,11 +1,9 @@
 package name.falgout.jeffrey.testing.junit.guice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -20,18 +18,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @SharedInjectors
 class SharedInjectorsTest {
 
-  private static final Random RANDOM = new Random();
-
-  private static String getRandomString() {
-    return String.valueOf(RANDOM.nextInt(Integer.MAX_VALUE));
-  }
-
   @Test
   @IncludeModule(TestCaseModule.class)
   @SharedInjectors
   void test1(@Named("base") String base, @Named("test") String test) {
-    assertNotNull(base);
-    assertNotNull(test);
+    assertEquals("base", base);
+    assertEquals("test", test);
   }
 
   @Test
@@ -52,9 +44,9 @@ class SharedInjectorsTest {
     void test1(@Named("base") String base,
         @Named("inner") String inner,
         @Named("test") String test) {
-      assertNotNull(base);
-      assertNotNull(test);
-      assertNotNull(inner);
+      assertEquals("base", base);
+      assertEquals("test", test);
+      assertEquals("inner", inner);
     }
   }
 
@@ -164,7 +156,7 @@ class SharedInjectorsTest {
 
     @Override
     protected void configure() {
-      bind(String.class).annotatedWith(Names.named("base")).toInstance(getRandomString());
+      bind(String.class).annotatedWith(Names.named("base")).toInstance("base");
     }
   }
 
@@ -172,7 +164,7 @@ class SharedInjectorsTest {
 
     @Override
     protected void configure() {
-      bind(String.class).annotatedWith(Names.named("inner")).toInstance(getRandomString());
+      bind(String.class).annotatedWith(Names.named("inner")).toInstance("inner");
     }
   }
 
@@ -180,7 +172,7 @@ class SharedInjectorsTest {
 
     @Override
     protected void configure() {
-      bind(String.class).annotatedWith(Names.named("test")).toInstance(getRandomString());
+      bind(String.class).annotatedWith(Names.named("test")).toInstance("test");
     }
   }
 


### PR DESCRIPTION
In original implementantion for each test guice create new injector and if we bind somting in scope SINGLETON - that not work as expected. 

In this pr I provide basic implementation of cache for injectors with same modules - can you provide some feedback?  @JeffreyFalgout 