### PR TITLE
switch from javax to jakarta namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,11 @@ hs_err_pid*
 .idea/
 *.iml
 
+# Eclipse
+.settings/
+.classpath
+.project
+.factorypath
+
 # Maven
 target/

--- a/disable-extension/src/test/java/name/falgout/jeffrey/testing/junit/disable/TestDisablerMetaTest.java
+++ b/disable-extension/src/test/java/name/falgout/jeffrey/testing/junit/disable/TestDisablerMetaTest.java
@@ -1,9 +1,9 @@
 package name.falgout.jeffrey.testing.junit.disable;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.Arrays;
 import name.falgout.jeffrey.testing.junit.testing.ExtensionTester;
 import name.falgout.jeffrey.testing.junit.testing.TestPlanExecutionReport;
 import name.falgout.jeffrey.testing.junit.testing.TestPlanExecutionReport.DisplayName;
@@ -34,13 +34,13 @@ class TestDisablerMetaTest {
         () -> assertThat(report.getTests()).hasSize(10),
         () ->
             assertThat(report.getSuccessful())
-                .containsAllOf(
+                .containsAtLeastElementsIn(Arrays.asList(
                     nestedFoo,
                     parameterized1,
-                    parameterized2),
+                    parameterized2)),
         () ->
             assertThat(report.getSkipped().keySet())
-                .containsAllOf(
+                .containsAtLeastElementsIn(Arrays.asList(
                     foo,
                     disableSpecificTest,
                     nestedBar,
@@ -48,7 +48,7 @@ class TestDisablerMetaTest {
                     nestedDifferentDisplayName,
                     nested2,
                     parameterized3,
-                    badTest),
+                    badTest)),
         () -> assertThat(report.getSkippedCause(foo)).hasValue("foo!"),
         () -> assertThat(report.getSkippedCause(nestedBaz)).hasValue("baz!")
     );

--- a/extension-testing/pom.xml
+++ b/extension-testing/pom.xml
@@ -64,8 +64,8 @@
       <artifactId>auto-value-annotations</artifactId>
     </dependency>
     <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
+        <groupId>jakarta.annotation</groupId>
+        <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>

--- a/extension-testing/src/main/java/name/falgout/jeffrey/testing/junit/testing/TestPlanExecutionReport.java
+++ b/extension-testing/src/main/java/name/falgout/jeffrey/testing/junit/testing/TestPlanExecutionReport.java
@@ -10,7 +10,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Optional;
 import java.util.Set;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.TestIdentifier;

--- a/extension-testing/src/test/java/name/falgout/jeffrey/testing/junit/testing/ExpectFailureTest.java
+++ b/extension-testing/src/test/java/name/falgout/jeffrey/testing/junit/testing/ExpectFailureTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.io.IOException;
+import java.util.Arrays;
 import name.falgout.jeffrey.testing.junit.testing.ExpectFailure.Cause;
 import name.falgout.jeffrey.testing.junit.testing.TestPlanExecutionReport.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -61,47 +62,50 @@ public class ExpectFailureTest {
         () -> assertThat(report.getTests()).hasSize(5),
         () ->
             assertThat(report.getFailures().keySet())
-                .containsAllOf(
-                    noExceptionThrown,
-                    wrongExceptionThrown,
-                    wrongCauseThrown,
+                .containsAtLeastElementsIn(Arrays.asList(
+                	noExceptionThrown,
+                	wrongExceptionThrown,
+                	wrongCauseThrown,
                     noCauseThrown,
-                    wrongMessage),
+                    wrongMessage)),
         () -> {
-          Throwable failure = report.getFailure(noExceptionThrown).get();
-          assertThat(failure).isInstanceOf(AssertionError.class);
-          assertThat(failure).hasMessageThat().contains("No exception was thrown!");
-        },
+            Throwable failure = report.getFailure(noExceptionThrown).get();
+            assertThat(failure).isInstanceOf(AssertionError.class);
+            assertThat(failure).hasMessageThat().contains("No exception was thrown!");
+          },
         () -> {
-          Throwable failure = report.getFailure(wrongExceptionThrown).get();
-          assertThat(failure).isInstanceOf(AssertionError.class);
-          assertThat(failure).hasMessageThat()
-              .contains("Not true that <java.lang.RuntimeException: Oops>"
-                  + " is an instance of <java.lang.IllegalArgumentException>");
-        },
+            Throwable failure = report.getFailure(wrongExceptionThrown).get();
+            assertThat(failure).isInstanceOf(AssertionError.class);
+            assertThat(failure).hasMessageThat()
+                .contains("expected instance of: java.lang.IllegalArgumentException\n"
+                		+ "but was instance of : java.lang.RuntimeException\n"
+                		+ "with value          : java.lang.RuntimeException: Oops");
+          },
         () -> {
-          Throwable failure = report.getFailure(wrongCauseThrown).get();
-          assertThat(failure).isInstanceOf(AssertionError.class);
-          assertThat(failure).hasMessageThat()
-              .contains("Unexpected cause for java.lang.IllegalArgumentException");
-          assertThat(failure).hasMessageThat()
-              .contains("Not true that <java.lang.RuntimeException: bar>"
-                  + " is an instance of <java.io.IOException>");
-        },
-        () -> {
-          Throwable failure = report.getFailure(noCauseThrown).get();
-          assertThat(failure).isInstanceOf(AssertionError.class);
-          assertThat(failure).hasMessageThat()
-              .contains("Unexpected cause for java.lang.IllegalArgumentException");
-          assertThat(failure).hasMessageThat()
-              .contains("Not true that <null> is an instance of <java.io.IOException>");
-        },
-        () -> {
-          Throwable failure = report.getFailure(wrongMessage).get();
-          assertThat(failure).isInstanceOf(AssertionError.class);
-          assertThat(failure).hasMessageThat()
-              .contains("Not true that <\"54321\"> contains <\"12345\">");
-        }
+            Throwable failure = report.getFailure(wrongCauseThrown).get();
+            assertThat(failure).isInstanceOf(AssertionError.class);
+            assertThat(failure).hasMessageThat()
+                .contains("value of            : throwable.getCause()\n"
+                		+ "expected instance of: java.io.IOException\n"
+                		+ "but was instance of : java.lang.RuntimeException\n"
+                		+ "with value          : java.lang.RuntimeException: bar");
+          },
+          () -> {
+            Throwable failure = report.getFailure(noCauseThrown).get();
+            assertThat(failure).isInstanceOf(AssertionError.class);
+            assertThat(failure).hasMessageThat()
+                .contains("value of            : throwable.getCause()\n"
+                		+ "expected instance of: java.io.IOException\n"
+                		+ "but was             : null");
+          },
+          () -> {
+            Throwable failure = report.getFailure(wrongMessage).get();
+            assertThat(failure).isInstanceOf(AssertionError.class);
+            assertThat(failure).hasMessageThat()
+                .contains("value of           : throwable.getMessage()\n"
+                		+ "expected to contain: 12345\n"
+                		+ "but was            : 54321");
+          }
     );
   }
 

--- a/extension-testing/src/test/java/name/falgout/jeffrey/testing/junit/testing/ExtentionTesterTest.java
+++ b/extension-testing/src/test/java/name/falgout/jeffrey/testing/junit/testing/ExtentionTesterTest.java
@@ -1,9 +1,9 @@
 package name.falgout.jeffrey.testing.junit.testing;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.Arrays;
 import name.falgout.jeffrey.testing.junit.testing.TestPlanExecutionReport.DisplayName;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -37,9 +37,9 @@ public class ExtentionTesterTest {
     assertAll(
         () -> assertThat(report.getTests()).hasSize(4),
         () -> assertThat(report.getSuccessful())
-            .containsAllOf(
+            .containsAtLeastElementsIn(Arrays.asList(
                 DisplayName.create("successful()"),
-                DisplayName.create("NestedTests", "nestedTest()")),
+                DisplayName.create("NestedTests", "nestedTest()"))),
         () ->
             assertThat(report.getSkippedCause(DisplayName.create("skipped()")))
                 .hasValue("reasons"),

--- a/guice-extension/pom.xml
+++ b/guice-extension/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.2.2</version>
+      <version>7.0.0</version>
     </dependency>
 
     <dependency>

--- a/guice-extension/src/main/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtension.java
+++ b/guice-extension/src/main/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtension.java
@@ -29,7 +29,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;

--- a/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtensionTest.java
+++ b/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/GuiceExtensionTest.java
@@ -8,7 +8,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import java.lang.reflect.InvocationTargetException;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import name.falgout.jeffrey.testing.junit.guice.GuiceExtensionTest.TestModule;
 import name.falgout.jeffrey.testing.junit.testing.ExpectFailure;
 import name.falgout.jeffrey.testing.junit.testing.ExpectFailure.Cause;

--- a/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/InjectExtensionsTest.java
+++ b/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/InjectExtensionsTest.java
@@ -4,7 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.inject.AbstractModule;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;

--- a/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/SharedInjectorsTest.java
+++ b/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/SharedInjectorsTest.java
@@ -7,7 +7,7 @@ import com.google.inject.name.Names;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.inject.Named;
+import jakarta.inject.Named;
 import name.falgout.jeffrey.testing.junit.guice.SharedInjectorsTest.OuterClassModule;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/SomeQualifyingAnnotation.java
+++ b/guice-extension/src/test/java/name/falgout/jeffrey/testing/junit/guice/SomeQualifyingAnnotation.java
@@ -7,7 +7,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 
 @Documented
 @Retention(RUNTIME)

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <junit.jupiter.version>5.5.2</junit.jupiter.version>
-    <junit.platform.version>1.5.2</junit.platform.version>
+    <junit.jupiter.version>5.11.3</junit.jupiter.version>
+    <junit.platform.version>1.11.3</junit.platform.version>
     <java.version>1.8</java.version>
     <base.url>https://github.com/JeffreyFalgout/junit5-extensions</base.url>
   </properties>
@@ -80,7 +80,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>22.0</version>
+        <version>33.3.1-jre</version>
       </dependency>
 
       <!-- Provided dependencies -->
@@ -93,25 +93,25 @@
       <dependency>
         <groupId>com.google.auto.value</groupId>
         <artifactId>auto-value</artifactId>
-        <version>1.6.3</version>
+        <version>1.11.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.google.auto.value</groupId>
         <artifactId>auto-value-annotations</artifactId>
-        <version>1.6.3</version>
+        <version>1.11.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
-        <version>1.0-rc4</version>
+        <version>1.1.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-          <version>1.2</version>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
+          <version>3.0.0</version>
           <scope>provided</scope>
       </dependency>
 
@@ -132,13 +132,13 @@
       <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
-        <version>0.33</version>
+        <version>1.4.4</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.google.truth.extensions</groupId>
         <artifactId>truth-java8-extension</artifactId>
-        <version>0.33</version>
+        <version>1.4.4</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
@@ -150,7 +150,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.13.0</version>
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
@@ -158,15 +158,15 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
+          <version>3.5.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.4.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.1.3</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -175,7 +175,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
+        <version>3.1.1</version>
         <configuration>
           <useReleaseProfile>false</useReleaseProfile>
           <releaseProfiles>release,ossrh</releaseProfiles>
@@ -195,7 +195,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.3.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -208,7 +208,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.1.1</version>
+            <version>3.11.2</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -221,7 +221,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -252,7 +252,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <version>1.7.0</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>


### PR DESCRIPTION
I've updated guice to 7.0.0 which uses the jakarta.inject instead of the old javax.inject namespace,
also updated dependencies with all the required changes (especial Truth made some breaking changes).